### PR TITLE
KQL can only select nodes

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -1,7 +1,7 @@
 # KDL Query Language Spec
 
 The KDL Query Language is a small language specially tailored for querying KDL
-documents to extract nodes and even specific data. It is loosely based on CSS
+documents to extract nodes. It is loosely based on CSS
 selectors for familiarity and ease of use. Think of it as CSS Selectors or
 XPath, but for KDL!
 


### PR DESCRIPTION
the spec, as it exists, only seems to specify how to select nodes.

while it is true that matchers can reference properties and arguments, these are only ever used for filtering, and cannot be returned from the query.

thus, i am proposing to remove this sentence as it is somewhat confusing.

being able to select arguments and properties, similar to how xpath `@prop` works, would be nice, but it would require a new version of the spec with significantly more features.